### PR TITLE
Add db_connection_name in dbal protocol (#13)

### DIFF
--- a/Components/DB/Dbal/ConfigurableDbalProtocol.php
+++ b/Components/DB/Dbal/ConfigurableDbalProtocol.php
@@ -10,6 +10,7 @@ class ConfigurableDbalProtocol extends Protocol implements DescriptableInterface
 {
     const OPTION_METHOD = 'method';
     const OPTION_STOP_ON_NO_RESULTS = 'stop_on_no_results';
+    const OPTION_DB_CONNECTION_NAME = 'db_connection_name';
 
     /**
      * Get static default options.
@@ -21,6 +22,7 @@ class ConfigurableDbalProtocol extends Protocol implements DescriptableInterface
         return array_merge(parent::getOptionsDescriptions(), [
             self::OPTION_METHOD => ['Method to be executed in the consumer/producer', []],
             self::OPTION_STOP_ON_NO_RESULTS => ['Consumer should stop on when all the records have been processed.', []],
+            self::OPTION_DB_CONNECTION_NAME => ['Option to chose which DB connection the consumer/producer should use', []],
         ]);
     }
 
@@ -38,10 +40,12 @@ class ConfigurableDbalProtocol extends Protocol implements DescriptableInterface
 
         $resolver->setDefaults([
             self::OPTION_STOP_ON_NO_RESULTS => false,
+            self::OPTION_DB_CONNECTION_NAME => '',
         ]);
 
         $resolver->setAllowedTypes(self::OPTION_METHOD, ['string']);
         $resolver->setAllowedTypes(self::OPTION_STOP_ON_NO_RESULTS, ['bool']);
+        $resolver->setAllowedTypes(self::OPTION_DB_CONNECTION_NAME, ['string']);
     }
 
     /**

--- a/Components/DB/Dbal/DbalStepsProvider.php
+++ b/Components/DB/Dbal/DbalStepsProvider.php
@@ -97,7 +97,7 @@ class DbalStepsProvider extends Service implements ConfigurableStepsProviderInte
      */
     public function executeStep($stepAction, array &$stepActionParams, array &$options, array &$context)
     {
-        if ($this->doctrine === null) {
+        if (null === $this->doctrine) {
             throw new \InvalidArgumentException('Doctrine should be installed to use DbalStepsProvider');
         }
 
@@ -268,7 +268,7 @@ class DbalStepsProvider extends Service implements ConfigurableStepsProviderInte
         if (array_key_exists(self::CONF_QUERY_NAME, $configuration)) {
             $name = $configuration[self::CONF_QUERY_NAME];
             $context[self::CONTEXT_RESULTS][$name] = $result;
-            if (count($result) == 0) {
+            if (0 == count($result)) {
                 throw new NoResultsException('No results found for query named: '.$name);
             }
         }
@@ -278,10 +278,17 @@ class DbalStepsProvider extends Service implements ConfigurableStepsProviderInte
 
     /**
      * @param $context
+     *
      * @return object
      */
     protected function getConnection($context)
     {
-        return $this->doctrine->getConnection();
+        $connectionName = null;
+
+        if (!empty($context['options']['db_connection_name'])) {
+            $connectionName = $context['options']['db_connection_name'];
+        }
+
+        return $this->doctrine->getConnection($connectionName);
     }
 }

--- a/Tests/Unit/Components/DB/Dbal/ConfigurableDbalProtocolTest.php
+++ b/Tests/Unit/Components/DB/Dbal/ConfigurableDbalProtocolTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Smartbox\Integration\FrameworkBundle\Tests\Unit\Components\Db\Dbal;
+
+use Smartbox\Integration\FrameworkBundle\Components\DB\Dbal\ConfigurableDbalProtocol;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Class RestConfigurableProducerTest.
+ */
+class ConfigurableDbalProtocolTest extends \PHPUnit_Framework_TestCase
+{
+    private $dbalProtocol;
+
+    private $expectedOptions;
+
+    protected function setUp()
+    {
+        $this->dbalProtocol = new ConfigurableDbalProtocol();
+        $this->expectedOptions = [
+            ConfigurableDbalProtocol::OPTION_METHOD,
+            ConfigurableDbalProtocol::OPTION_STOP_ON_NO_RESULTS,
+            ConfigurableDbalProtocol::OPTION_DB_CONNECTION_NAME,
+        ];
+    }
+
+    protected function tearDown()
+    {
+        $this->dbalProtocol = null;
+        $this->expectedOptions = null;
+    }
+
+    /**
+     * Method to test the options descriptions available for this protocol.
+     */
+    public function testGetOptionsDescriptions()
+    {
+        $options = $this->dbalProtocol->getOptionsDescriptions();
+
+        foreach ($this->expectedOptions as $expectedOption) {
+            $this->assertArrayHasKey($expectedOption, $options);
+        }
+    }
+
+    /**
+     * Method to test if the options resolver is configured with the expected options.
+     */
+    public function testConfigureOptionsResolver()
+    {
+        $resolver = new OptionsResolver();
+
+        $this->dbalProtocol->configureOptionsResolver($resolver);
+
+        foreach ($this->expectedOptions as $expectedOption) {
+            $this->assertTrue($resolver->isDefined($expectedOption));
+        }
+    }
+}

--- a/Tests/Unit/Components/DB/Dbal/DbalStepsProviderTest.php
+++ b/Tests/Unit/Components/DB/Dbal/DbalStepsProviderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Smartbox\Integration\FrameworkBundle\Tests\Unit\Components\DB\Dbal;
+
+use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use Smartbox\Integration\FrameworkBundle\Components\DB\Dbal\DbalStepsProvider;
+use Smartbox\Integration\FrameworkBundle\Configurability\ConfigurableServiceHelper;
+
+class DbalStepsProviderTest extends \PHPUnit_Framework_TestCase
+{
+    private $dbalStepsProvider;
+
+    protected function setUp()
+    {
+        $this->dbalStepsProvider = new DbalStepsProvider();
+    }
+
+    protected function tearDown()
+    {
+        $this->dbalStepsProvider = null;
+    }
+
+    public function contextProvider()
+    {
+        return [
+            'Context contains a specific database connection name' => [
+                'context' => [
+                    'options' => [
+                        'db_connection_name' => 'dbtest',
+                    ],
+                ],
+                'options' => [
+                    'db_connection_name' => 'dbtest',
+                ],
+                'db_connection_name' => 'dbtest',
+            ],
+            'Context does not contain specific database connection name' => [
+                'context' => [],
+                'options' => [],
+                'db_connection_name' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider contextProvider
+     *
+     * @param array $context
+     * @param array $options
+     */
+    public function testDoctrineGetConnection(array $context, array $options, $connectionName)
+    {
+        $parameters = [];
+        $sql = 'SELECT test FROM test';
+
+        $stmt = $this->getMockBuilder(Statement::class)->getMock();
+        $stmt->expects($this->once())
+            ->method('columnCount')
+            ->will($this->returnValue(1));
+        $stmt->expects($this->once())
+            ->method('fetchAll')
+            ->will($this->returnValue(['test' => 1]));
+
+        $dbal = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dbal->expects($this->once())
+            ->method('executeQuery')
+            ->will($this->returnValue($stmt));
+
+        $doctrine = $this->getMockBuilder(Registry::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $doctrine->expects($this->once())
+            ->method('getConnection')
+            ->with($connectionName)
+            ->will($this->returnValue($dbal));
+
+        $confHelper = $this->getMockBuilder(ConfigurableServiceHelper::class)->getMock();
+        $confHelper->expects($this->exactly(2))
+            ->method('resolve')
+            ->will($this->onConsecutiveCalls($parameters, $sql));
+
+        $action = 'execute';
+        $actionParams = [
+            'sql' => $sql,
+            'parameters' => $parameters,
+        ];
+
+        $this->dbalStepsProvider->setDoctrine($doctrine);
+        $this->dbalStepsProvider->setConfHelper($confHelper);
+        $this->dbalStepsProvider->executeStep($action, $actionParams, $options, $context);
+    }
+}

--- a/Tests/Unit/Components/WebService/Rest/RestConfigurableProducerTest.php
+++ b/Tests/Unit/Components/WebService/Rest/RestConfigurableProducerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Smartbox\Integration\FrameworkBundle\Tests\Components\WebService\Rest;
+namespace Smartbox\Integration\FrameworkBundle\Tests\Unit\Components\WebService\Rest;
 
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;


### PR DESCRIPTION
* Add database_name option in ConfigurableDbalProtocol
- Use database_name value in DbalStepsProvider
- Add UT for DbalStepsProvicer and ConfigurableDbalProtocol
- Fix namespace in RestConfigurableProducerTest

* Rename database_name protocol option in dbal to db_connection_name
- Update the UTs to use the new protocol option
- Run php-cs-fixer to the php files modified